### PR TITLE
Add explicit JSONB cast in SQL query

### DIFF
--- a/services/identity/routes.py
+++ b/services/identity/routes.py
@@ -928,7 +928,7 @@ async def submit_question_responses(
             """
             INSERT INTO user_question_responses 
             (user_id, question_id, response_value, session_id, dust_reward)
-            VALUES ($1, $2, $3, $4, $5)
+            VALUES ($1, $2, $3::jsonb, $4, $5)
             RETURNING *
             """,
             user_id, response.question_id, response_value, 


### PR DESCRIPTION
- Use ::jsonb to explicitly cast JSON string to JSONB type
- Ensures PostgreSQL properly handles the JSON string parameter
- Should resolve remaining database insertion errors

🤖 Generated with [Claude Code](https://claude.ai/code)