### PR TITLE
Add debug logging to diagnose TripAdvisor API authentication

### DIFF
--- a/services/content/tripadvisor_service.py
+++ b/services/content/tripadvisor_service.py
@@ -46,6 +46,11 @@ class TripAdvisorService:
                         "limit": 30,  # Get more results to filter and prioritize
                     }
 
+                    print(f"🔍 TRIPADVISOR_DEBUG: API Key: {self.api_key[:10]}...", flush=True)
+                    print(f"🔍 TRIPADVISOR_DEBUG: Headers: {self.headers}", flush=True)
+                    print(f"🔍 TRIPADVISOR_DEBUG: URL: {self.base_url}/location/nearby_search", flush=True)
+                    print(f"🔍 TRIPADVISOR_DEBUG: Params: {params}", flush=True)
+
                     response = await client.get(
                         f"{self.base_url}/location/nearby_search",
                         headers=self.headers,


### PR DESCRIPTION
- Added detailed debug output in tripadvisor_service.py
- Logs API key (first 10 chars), headers, URL, and params
- DUST balance now working correctly (156 DUST)
- TripAdvisor API returning 401 - likely missing env var

🤖 Generated with [Claude Code](https://claude.ai/code)