### PR TITLE
Add version tracking to admin portal (v2.1.0)

### DIFF
--- a/services/admin-ui/src/components/layout/Sidebar.tsx
+++ b/services/admin-ui/src/components/layout/Sidebar.tsx
@@ -121,6 +121,12 @@ export function Sidebar({ className }: SidebarProps) {
               <LogOut className="h-4 w-4 mr-2" />
               Logout
             </Button>
+            {/* Version Info */}
+            <div className="text-center pt-2 border-t border-slate-700">
+              <p className="text-xs text-slate-500">
+                Admin Portal v2.1.0
+              </p>
+            </div>
           </div>
         ) : (
           <div className="space-y-2">

--- a/services/admin-ui/src/components/ui/label.tsx
+++ b/services/admin-ui/src/components/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/services/admin-ui/src/components/ui/textarea.tsx
+++ b/services/admin-ui/src/components/ui/textarea.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+function Textarea({ className, ...props }: TextareaProps) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/services/admin-ui/src/pages/Dashboard.tsx
+++ b/services/admin-ui/src/pages/Dashboard.tsx
@@ -91,6 +91,18 @@ export function Dashboard() {
 
   return (
     <div className="space-y-6">
+      {/* Header with Version */}
+      <div className="flex justify-between items-start">
+        <div>
+          <h1 className="text-3xl font-bold text-slate-900">Dashboard</h1>
+          <p className="text-slate-500">Welcome to the fairydust admin portal</p>
+        </div>
+        <div className="text-right">
+          <p className="text-sm text-slate-400">Admin Portal</p>
+          <p className="text-lg font-semibold text-slate-600">v2.1.0</p>
+        </div>
+      </div>
+
       {/* System Health Alert */}
       {hasSystemIssues && (
         <Alert className="border-yellow-200 bg-yellow-50">

--- a/services/admin/static/index.html
+++ b/services/admin/static/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Fairydust Admin Portal</title>
+    <title>Fairydust Admin Portal v2.1.0</title>
     <script type="module" crossorigin src="/assets/index-BK26B6g7.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-63cmQ8zi.css">
   </head>


### PR DESCRIPTION
🏷️ Added version display in two locations:
1. **Sidebar Footer**: Always visible version info "Admin Portal v2.1.0"
2. **Dashboard Header**: Prominent version display in top-right corner
3. **Browser Tab**: Updated title to include version number

📍 **Where to find the version:**
- Left sidebar at the bottom (when expanded)
- Dashboard page top-right corner
- Browser tab title shows "v2.1.0"

🎯 **Version: 2.1.0**
- This version includes all the critical admin portal fixes
- Apps page database fixes
- LLM Analytics database column fixes
- System Status Alert logic corrections

✨ Now you can easily verify you're looking at the latest deployed code by checking any of these three locations.

🤖 Generated with [Claude Code](https://claude.ai/code)